### PR TITLE
Update argonaut compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,10 +10,10 @@
     "purescript-nullable": "^4.1.1",
     "purescript-exceptions": "^4.0.0",
     "purescript-monad-control": "^5.0.0",
-    "purescript-argonaut": "^6.0.0",
+    "purescript-argonaut": "^7.0.0",
     "purescript-generics-rep": "^6.1.1",
     "purescript-foreign": "^5.0.0",
-    "purescript-web-file": "^2.2.0",
+    "purescript-web-file": "^2.3.0",
     "purescript-arraybuffer": "^10.0.2",
     "purescript-text-encoding": "^1.0.0"
   },

--- a/packages.dhall
+++ b/packages.dhall
@@ -121,7 +121,11 @@ let additions =
 let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200423/packages.dhall sha256:c180a06bb5444fd950f8cbdd6605c644fd246deb397e62572b8f4a6b9dbcaf22
 
-let overrides = {=}
+let overrides = 
+  { argonaut = upstream.argonaut // { version = "v7.0.0" }
+  , argonaut-codecs = upstream.argonaut-codecs // { version = "v7.0.0" }
+  , argonaut-traversals = upstream.argonaut-traversals // { version = "v8.0.0" }
+  }
 
 let additions =
   { text-encoding =

--- a/src/WebSocket.purs
+++ b/src/WebSocket.purs
@@ -15,22 +15,22 @@ module WebSocket
   , isBinary
   ) where
 
-import Prelude ((*>), Unit, class Applicative, (<<<), pure, unit, ($), class Semigroup, class Monoid, mempty, (>>=), class Bind)
-import Data.Nullable (Nullable, toMaybe, toNullable)
-import Data.Maybe (Maybe)
-import Data.Either (Either (..))
-import Data.Argonaut (class EncodeJson, class DecodeJson, encodeJson, decodeJson, jsonParser, stringify, Json)
-import Data.Profunctor (class Profunctor)
-import Data.Generic.Rep (class Generic)
+import Data.Argonaut (class DecodeJson, class EncodeJson, Json, decodeJson, encodeJson, jsonParser, printJsonDecodeError, stringify)
 import Data.ArrayBuffer.Types (ArrayBuffer)
-import Data.Symbol (SProxy (..), reflectSymbol, class IsSymbol)
-import Web.File.Blob (Blob)
-import Foreign (Foreign)
+import Data.Either (Either(..))
+import Data.Generic.Rep (class Generic)
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe, toNullable)
+import Data.Profunctor (class Profunctor)
+import Data.Symbol (SProxy(..), reflectSymbol, class IsSymbol)
 import Effect (Effect)
-import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, mkEffectFn1, mkEffectFn2)
-import Effect.Exception (Error, throw)
 import Effect.Class (class MonadEffect, liftEffect)
-import Type.Proxy (Proxy (..))
+import Effect.Exception (Error, throw)
+import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, mkEffectFn1, mkEffectFn2)
+import Foreign (Foreign)
+import Prelude ((*>), Unit, class Applicative, (<<<), pure, unit, ($), class Semigroup, class Monoid, mempty, (>>=), class Bind)
+import Type.Proxy (Proxy(..))
+import Web.File.Blob (Blob)
 
 
 
@@ -146,7 +146,7 @@ dimapJson = dimap' fromJson encodeJson
     fromJson :: Json -> m receive
     fromJson x = case decodeJson x of
       Right y -> pure y
-      Left e -> liftEffect (throw e)
+      Left e -> liftEffect (throw (printJsonDecodeError e))
 
 
 


### PR DESCRIPTION
The most recent [major release of the Argonaut library](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0) introduces typed errors. This PR updates this library for compatibility via Bower or Spago.

I added overrides so that this can be built via Spago locally. Those overrides can be removed once the next package set is released, as tracked by this issue:
https://github.com/purescript/package-sets/issues/642

If everything looks good, would you mind making a new release with the updated code so it's compatible with the upcoming package set? That'll ensure this package stays in the set. Once the next package set is released then it can be updated in this project's `spago.dhall` file and the overrides can be removed (they won't be necessary anymore).

Sorry for the hassle! Thanks!